### PR TITLE
fix undefined reference to dlsym

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -196,3 +196,34 @@ jobs:
           cmake3 .. -DTESTS=ON
           make -j2
           CTEST_OUTPUT_ON_FAILURE=TRUE make test
+  build_with_windows:
+    name: build_with_windows
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-2019]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 5
+      - uses: actions/cache@v2
+        id: cache
+        with:
+          path: |
+            /home/runner/.hunter
+            /github/home/.hunter
+            /Users/runner/.hunter
+            C:/.hunter/
+            ccache
+          key: hunter-msvc-v1-notest-${{ runner.temp }}-${{ github.base_ref }}-${{ hashFiles('.github/workflows/workflow.yml') }}
+          restore-keys: |
+            hunter-msvc-v1-notest-${{ runner.temp }}-${{ github.base_ref }}-${{ hashFiles('.github/workflows/workflow.yml') }}
+            hunter-msvc-v1-notest-${{ runner.temp }}-${{ github.base_ref }}-
+            hunter-msvc-v1-notest-${{ runner.temp }}-
+      - name: Add MSbuild to PATH
+        uses: microsoft/setup-msbuild@v1.1
+      - name: configure
+        if: runner.os == 'Windows'
+        run: mkdir -p build && cd build && cmake -G "Visual Studio 16 2019" -A x64 .. -DHUNTER_CONFIGURATION_TYPES=Release -DHUNTER_STATUS_DEBUG=ON
+      - name: compile
+        run: cd build && MSBuild bcos-crypto.sln /p:Configuration=Release /p:Platform=x64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ option(DEMO "compile demo or not" OFF)
 
 set(BCOS_CRYPTO_TARGET bcos-crypto)
 add_library(${BCOS_CRYPTO_TARGET} ${SRC_LIST} ${HEADERS})
-target_link_libraries(${BCOS_CRYPTO_TARGET} PUBLIC bcos-utilities::bcos-utilities wedpr-crypto::crypto)
+target_link_libraries(${BCOS_CRYPTO_TARGET} PUBLIC bcos-utilities::bcos-utilities wedpr-crypto::crypto pthread dl)
 
 if(DEMO)
 add_subdirectory(demo)


### PR DESCRIPTION
Fix the error of FISCO BCOS link bcos-crypto under centos system:

```bash
root/.hunter/_Base/0216540/8634957/ce603ad/Install/lib/libffi_c_crypto_binary.a(std-363511a59ca6fedb.std.2k3kczsj-cgu.0.rcgu.o):std.2k3kczsj-cgu.0:function std::env::home_dir: warning: Using 'getpwuid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/root/.hunter/_Base/0216540/8634957/ce603ad/Install/lib/libffi_c_crypto_binary.a(std-363511a59ca6fedb.std.2k3kczsj-cgu.0.rcgu.o):std.2k3kczsj-cgu.0:function <std::sys_common::net::LookupHost as core::convert::TryFrom<(&str,u16)>>::try_from: warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/root/.hunter/_Base/0216540/8634957/ce603ad/Install/lib/libffi_c_crypto_binary.a(std-363511a59ca6fedb.std.2k3kczsj-cgu.0.rcgu.o):std.2k3kczsj-cgu.0:function std::sys::unix::weak::Weak<F>::initialize: error: undefined reference to 'dlsym'
/root/.hunter/_Base/0216540/8634957/ce603ad/Install/lib/libffi_c_crypto_binary.a(std-363511a59ca6fedb.std.2k3kczsj-cgu.0.rcgu.o):std.2k3kczsj-cgu.0:function std::sys::unix::weak::Weak<F>::initialize: error: undefined reference to 'dlsym'
/root/.hunter/_Base/0216540/8634957/ce603ad/Install/lib/libffi_c_crypto_binary.a(std-363511a59ca6fedb.std.2k3kczsj-cgu.0.rcgu.o):std.2k3kczsj-cgu.0:function std::sys::unix::weak::Weak<F>::initialize: error: undefined reference to 'dlsym'
/root/.hunter/_Base/0216540/8634957/ce603ad/Install/lib/libffi_c_crypto_binary.a(std-363511a59ca6fedb.std.2k3kczsj-cgu.0.rcgu.o):std.2k3kczsj-cgu.0:function std::sys::unix::weak::Weak<F>::initialize: error: undefined reference to 'dlsym'
```